### PR TITLE
added an overload to pass a CancellationToken

### DIFF
--- a/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
+++ b/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
@@ -1,4 +1,6 @@
 using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace LibreTranslate.Net.Tests
 {
@@ -12,18 +14,18 @@ namespace LibreTranslate.Net.Tests
         [Test]
         public void Test1()
         {
-            var libreTranslate = new LibreTranslate();
+            var libreTranslate = new LibreTranslate("https://translate.rinderha.cc");
             var englishText = "Hello World!";
             var TranslateAsyncTask = libreTranslate.TranslateAsync(new Translate()
             {
-                ApiKey = "MySecretApiKey",
+                ApiKey = "",
                 Source = LanguageCode.English,
                 Target = LanguageCode.Spanish,
                 Text = englishText
             });
-            System.Threading.Tasks.Task.Run(() => TranslateAsyncTask).Wait();
+            Task.Run(() => TranslateAsyncTask).Wait();
             var spanishText = TranslateAsyncTask.Result;
-            Assert.AreEqual(spanishText, "¡Hola Mundo!");
+            Assert.AreEqual("¡Hola Mundo!", spanishText);
 
             //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.En));
             //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Ar));
@@ -35,6 +37,41 @@ namespace LibreTranslate.Net.Tests
             //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Ru));
             //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Es));
             //assumes server has all languages available!
+        }
+
+        [Test]
+        public void Test2()
+        {
+            var libreTranslate = new LibreTranslate("https://translate.rinderha.cc");
+            var englishText = "Hello World!";
+            var tokenSource = new CancellationTokenSource();
+            Task.Run(() => InnerTestAsyncDecouple());
+            Thread.Sleep(200);
+            tokenSource.Cancel();
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.En));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Ar));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Zh));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Fr));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.De));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.It));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Pt));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Ru));
+            //Assert.True(translate.SupportedLanguages().Contains(LanguageCode.Es));
+            //assumes server has all languages available!
+
+            async void InnerTestAsyncDecouple()
+            {
+                var TranslateAsyncTask = libreTranslate.TranslateAsync(new Translate()
+                {
+                    ApiKey = "",
+                    Source = LanguageCode.English,
+                    Target = LanguageCode.Spanish,
+                    Text = englishText
+                },
+                tokenSource.Token);
+                _ = await TranslateAsyncTask;
+                Assert.AreEqual(TaskStatus.Canceled, TranslateAsyncTask.Status);
+            }
         }
     }
 }

--- a/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
+++ b/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
@@ -14,7 +14,7 @@ namespace LibreTranslate.Net.Tests
         [Test]
         public void Test1()
         {
-            var libreTranslate = new LibreTranslate("https://translate.rinderha.cc");
+            var libreTranslate = new LibreTranslate();
             var englishText = "Hello World!";
             var TranslateAsyncTask = libreTranslate.TranslateAsync(new Translate()
             {

--- a/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
+++ b/LibreTranslate.Net.Tests/LibreTranslate.Net.Test1.cs
@@ -42,7 +42,7 @@ namespace LibreTranslate.Net.Tests
         [Test]
         public void Test2()
         {
-            var libreTranslate = new LibreTranslate("https://translate.rinderha.cc");
+            var libreTranslate = new LibreTranslate();
             var englishText = "Hello World!";
             var tokenSource = new CancellationTokenSource();
             Task.Run(() => InnerTestAsyncDecouple());


### PR DESCRIPTION
this is so the calls to HttpClient can be safely cancelled now that Thread.Abort has been removed from .NET